### PR TITLE
Fixed src file paths not getting expanded.

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
     grunt.verbose.writeflags(globals, 'JSHint globals');
 
     // Lint specified files.
-    var files = this.file.src;
+    var files = grunt.file.expandFiles(this.file.src);
     files.forEach(function(filepath) {
       jshint.lint(grunt.file.read(filepath), options, globals, filepath);
     });


### PR DESCRIPTION
For example, the Gruntfile.js in this very repository uses wildcards, which fails due to grunt trying to open a `tasks/*.js` file. Fixed by adding a `grunt.file.expandFiles` call in there.

Note that the `jshint` command itself can also accept directories, but it doesn't look like grunt-contrib-jshint supports that, so I went with expandFiles.
