### PR TITLE
Added a jshintignore option

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+test/fixtures/dirty.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,17 +16,20 @@ module.exports = function(grunt) {
       all_files: [
         'Gruntfile.js',
         'tasks/*.js',
-        '<%= nodeunit.tests %>'
+        '<%= nodeunit.tests %>',
+        'test/fixtures/*.js'
       ],
       individual_files: {
         files: [
           {src: 'Gruntfile.js'},
           {src: 'tasks/*.js'},
           {src: '<%= nodeunit.tests %>'},
+          {src: 'test/fixtures/*.js'}
         ]
       },
       options: {
         jshintrc: '.jshintrc',
+        jshintignore: '.jshintignore'
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,29 @@ If this filename is specified, options and globals defined therein will be used.
 }
 ```
 
+#### jshintignore
+Type: `String`
+Default value: `null`
+
+If this filename is given then any directories or files specified will be skipped over.
+For example, there are two files `foo/bar.js` and `foo/baz.js`, and the content of `.jshintignore` is
+
+```
+foo/bar.js
+```
+
+then following `jshint` task checks `foo/baz.js` but ignores `foo/bar.js`.
+
+```javascript
+jshint: {
+  all: ["foo/*.js"],
+  options: {
+    jshintrc: ".jshintrc",
+    jshintignore: ".jshintignore"
+  }
+}
+```
+
 ### Usage examples
 
 #### Wildcards
@@ -124,10 +147,10 @@ grunt.initConfig({
 
 ## Release History
 
- * 2012-10-17   v0.1.0   Work in progress, not yet officially released.
+ * 2012-10-18   v0.1.0   Work in progress, not yet officially released.
 
 ---
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Wed Nov 28 2012 08:49:23.*
+*This file was generated on Sun Dec 30 2012 01:56:18.*

--- a/docs/jshint-options.md
+++ b/docs/jshint-options.md
@@ -30,3 +30,26 @@ If this filename is specified, options and globals defined therein will be used.
   }
 }
 ```
+
+## jshintignore
+Type: `String`
+Default value: `null`
+
+If this filename is given then any directories or files specified will be skipped over.
+For example, there are two files `foo/bar.js` and `foo/baz.js`, and the content of `.jshintignore` is
+
+```
+foo/bar.js
+```
+
+then following `jshint` task checks `foo/baz.js` but ignores `foo/bar.js`.
+
+```javascript
+jshint: {
+  all: ["foo/*.js"],
+  options: {
+    jshintrc: ".jshintrc",
+    jshintignore: ".jshintignore"
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "jshint": "~0.9.0"
+    "jshint": "~0.9.0",
+    "minimatch": "~0.0.5"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.1.0",

--- a/test/fixtures/clean.js
+++ b/test/fixtures/clean.js
@@ -1,0 +1,5 @@
+(function () {
+
+  "use strict";
+
+})();

--- a/test/fixtures/dirty.js
+++ b/test/fixtures/dirty.js
@@ -1,0 +1,1 @@
+dirty js file.


### PR DESCRIPTION
This patch solves #1.

If a filename is given as `jshintignore` option then any directories or files specified will be skipped over.
For example, there are two files `foo/bar.js` and `foo/baz.js`, and the content of `.jshintignore` is

```
foo/bar.js
```

then following `jshint` task checks `foo/baz.js` but ignores `foo/bar.js`.

``` javascript
jshint: {
  all: ["foo/*.js"],
  options: {
    jshintignore: ".jshintignore"
  }
}
```
