### PR TITLE
Fall back to this.file.src or empty array

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -39,8 +39,8 @@ module.exports = function(grunt) {
     grunt.verbose.writeflags(options, 'JSHint options');
     grunt.verbose.writeflags(globals, 'JSHint globals');
 
-    // Lint specified files.
-    var files = this.filesSrc;
+    // Lint specified files
+    var files = this.filesSrc || this.file.src || [];
     files.forEach(function(filepath) {
       jshint.lint(grunt.file.read(filepath), options, globals, filepath);
     });


### PR DESCRIPTION
I'm currently having some trouble getting this to run straight out of the box and narrowed it down to the use of `this.filesSrc`.  

This proposed change will fall back to this.file.src if this.filesSrc is not available, or to an empty array which will prevent any further errors should the file sources not be defined.
