### PR TITLE
Ensure path is a file before trying to lint.

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -42,7 +42,9 @@ module.exports = function(grunt) {
     // Lint specified files.
     var files = this.filesSrc;
     files.forEach(function(filepath) {
-      jshint.lint(grunt.file.read(filepath), options, globals, filepath);
+      if (grunt.file.isFile(filepath)) {
+        jshint.lint(grunt.file.read(filepath), options, globals, filepath);
+      }
     });
 
     // Fail task if errors were logged.


### PR DESCRIPTION
This task was failing for me with the error:

```
Warning: Unable to read "app/scripts/components/spin.js" file (Error code: EISDIR). Use --force to continue.
```

It appears that app/scripts/components/spin.js was returned from the globbing pattern because it contained ".js". Unfortunately, that's a directory.

I imagine spin.js isn't the only project with a directory name like this, so it seems sensible to check first that the path is a file before trying to lint.
