### PR TITLE
Include jshint error/warning code in message

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -73,6 +73,7 @@ exports.init = function(grunt) {
       // Sometimes there's no error object.
       if (!e) { return; }
       var pos;
+      var code = '';
       var evidence = e.evidence;
       var character = e.character;
       if (evidence) {
@@ -80,7 +81,10 @@ exports.init = function(grunt) {
         grunt.fail.errorcount++;
         // Descriptive code error.
         pos = '['.red + ('L' + e.line).yellow + ':'.red + ('C' + character).yellow + ']'.red;
-        grunt.log.writeln(pos + ' ' + e.reason.yellow);
+        if (e.code) {
+            code = e.code.yellow + ':'.red + ' ';
+        }
+        grunt.log.writeln(pos + ' ' + code + e.reason.yellow);
         // If necessary, eplace each tab char with something that can be
         // swapped out later.
         if (tabstr) {


### PR DESCRIPTION
This commit adds the jshint error/warning code in the message output as described in issue #21.
