### PR TITLE
Fix #1, #9 and #29. Add ignores support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _Run this task with the `grunt jshint` command._
 Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
 ### Options
 
-Any specified option will be passed through directly to [JSHint][], thus you can specify any option that JSHint supports. See the [JSHint documentation][] for a list of supported options.
+Any specified option will be passed through directly to [JSHint][], thus you can specify any option that JSHint supports. See the [JSHint documentation][] for a list of supported options. Any exclusions defined within `.jshintignore` will also be respected. The `.jshintignore` file should be in the same directory as your `Gruntfile.js`.
 
 [JSHint]: http://www.jshint.com/
 [JSHint documentation]: http://www.jshint.com/docs/
@@ -64,6 +64,12 @@ Type: `Boolean`
 Default value: `false`
 
 Set `force` to `true` to report JSHint errors but not fail the task.
+
+#### extra-ext
+Type: `String`
+Default value: `""`
+
+A list of non-dot-js extensions to lint. You never need to supply `js` as it is always assumed.
 
 ### Usage examples
 
@@ -148,4 +154,4 @@ grunt.initConfig({
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Mon Apr 08 2013 14:53:42.*
+*This file was generated on Tue Apr 09 2013 20:44:31.*

--- a/docs/jshint-options.md
+++ b/docs/jshint-options.md
@@ -36,3 +36,9 @@ Type: `Boolean`
 Default value: `false`
 
 Set `force` to `true` to report JSHint errors but not fail the task.
+
+## extra-ext
+Type: `String`
+Default value: `""`
+
+A list of non-dot-js extensions to lint. You never need to supply `js` as it is always assumed.

--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -17,12 +17,17 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('jshint', 'Validate files with JSHint.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-      force: false
+      force: false,
+      'extra-ext': ''
     });
 
     // Report JSHint errors but dont fail the task
     var force = options.force;
     delete options.force;
+
+    // Are extra extension defined?
+    var extensions = options['extra-ext'];
+    delete options['extra-ext'];
 
     // Read JSHint options from a specified jshintrc file.
     if (options.jshintrc) {
@@ -51,7 +56,7 @@ module.exports = function(grunt) {
 
     // Lint specified files.
     var files = this.filesSrc;
-    cli.gather({ args: files, extensions: "" }).forEach(function(filepath) {
+    cli.gather({ args: files, extensions: extensions }).forEach(function(filepath) {
       jshint.lint(grunt.file.read(filepath), options, globals, filepath);
     });
 


### PR DESCRIPTION
This pull request add `.jshintignore` support to the jshint task config. Since https://github.com/jshint/jshint/pull/949 has been merged upstream into jshint, this is a relatively simple change. 

In order to load the default the `.jshintignore` from a projects root there is no config change needed. It will be loaded by default.

Should you want to define custom ignores you can use the `ignores` option. This is an array where each element represents a line of the `.jshintignore` files. An example config would look like:

``` javascript
    grunt.initConfig({
        jshint: {
            all: ['*.js'],
            options: {
                jshintrc: '.jshintrc',
                ignores: [
                    'lib/',
                    'path/to/3rdparty/lib.js'
                ]
            }
        }
    });
```
