### PR TITLE
Fix predef object evaluation

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
     }
     // Convert deprecated "predef" array|object into globals.
     if (options.predef) {
-      if (options.predef === Object(options.predef)) {
+      if (!Array.isArray(options.predef) && typeof options.predef === "object") {
         options.predef = Object.keys(options.predef);
       }
       options.predef.forEach(function(key) {


### PR DESCRIPTION
This fixes an issue introduced by https://github.com/grunt/grunt-contrib-jshint/commit/fc7938f6c799f559dc3b1495c06d872228960239 where if `predef` is an array it's no longer evaluated correctly because:

``` javascript
var a = ['a','b','c'];
typeof a === "object"; // true
a === Object(a); // true
Object.keys(a); // [0,1,2] (expects ['a','b','c'])
```

Instead using the object type check as documented in IdomaticJS (https://github.com/rwldrn/idiomatic.js/#type)

``` javascript
var a = ['a','b','c'];
Array.isArray(a); // true
typeof options.predef === "object"; // true
```
