### PR TITLE
Use force option with a jshintrc file

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -25,7 +25,8 @@ module.exports = function(grunt) {
 
     // Read JSHint options from a specified jshintrc file.
     if (options.jshintrc) {
-      options = grunt.file.readJSON(options.jshintrc);
+      options = this.options(grunt.file.readJSON(options.jshintrc));
+      delete options.jshintrc;
     }
     // If globals weren't specified, initialize them as an empty object.
     if (!options.globals) {


### PR DESCRIPTION
When i specified a jshintrc file, it takes options from this file, just as expected. But the problem is the option `force` is not in my jshintrc, because it's not a valid jshint option, so there is no way to pass `force` option.

When i build using grunt, the force option is not present and my task doesn't fail when there is some linting errors.

I have fixed this with an extend of options instead of a replacement.
