### PR TITLE
Bump jshint to 2.0.x. Fixes GH-51

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~1.1.0"
+    "jshint": "~2.0.1"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.1.2",


### PR DESCRIPTION
This pull request bumps the jshint dependency to 2.0.x. The only breaking change is es5 option is now on by default.

JSHint has changed the logic for .jshint path resolution, but this plugin completely bypasses that by passing the config options in directly so it's not an issue.

I've anecdotally testing against my current code base for 400+ js files and all is well.
