### PR TITLE
Execute the reporter once. Fixes GH-54.

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -194,22 +194,18 @@ exports.init = function(grunt) {
     cliOptions.config = options;
     grunt.verbose.writeflags(options, 'JSHint options');
 
-    // Run JSHint on each file and collect results/data
+    // Run JSHint on all file and collect results/data
     var allResults = [];
     var allData = [];
-    grunt.util.async.forEach(files, function(filepath, next) {
-      var cliopts = grunt.util._.clone(cliOptions);
-      cliopts.args = [filepath];
-      cliopts.reporter = function(results, data) {
-        reporter(results, data);
-        allResults = allResults.concat(results);
-        allData = allData.concat(data);
-        next();
-      };
-      jshintcli.run(cliopts);
-    }, function() {
-      done(allResults, allData);
-    });
+    var cliopts = grunt.util._.clone(cliOptions);
+    cliopts.args = files;
+    cliopts.reporter = function(results, data) {
+      reporter(results, data);
+      allResults = allResults.concat(results);
+      allData = allData.concat(data);
+    };
+    jshintcli.run(cliopts);
+    done(allResults, allData);
   };
 
   return exports;

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -109,4 +109,19 @@ exports.jshint = {
       test.done();
     });
   },
+  singleReportCall: function(test) {
+    test.expect(2);
+
+    // stub jshint.reporter
+    var reporterCallCount = 0;
+    var _report = jshint.reporter;
+    jshint.reporter = function() { reporterCallCount++; };
+
+    var files = [path.join(fixtures, 'dontlint.txt'), path.join(fixtures, 'lint.txt')];
+    jshint.lint(files, {}, function(results, data) {
+      test.equal(data.length, 1, 'Should not have linted a file listed in the .jshintignore.');
+      test.equal(reporterCallCount, 1, 'Should have called the reporter once.');
+      test.done();
+    });
+  }
 };


### PR DESCRIPTION
This pull request ensures the reporter is only executed once per execution preventing superfluous output fixing #54.

IMHO e4c6ad1ea80fe191254ffcd59bbbf2a80b30b636 should be reverted before applying this fix to keep the reporter logic simple.
