### PR TITLE
Default reporter should show the offending file. Fixes GH-57. Closes GH-57.

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -87,9 +87,6 @@ exports.init = function(grunt) {
       return;
     }
 
-    var msg = 'Linting' + (data[0].file ? ' ' + data[0].file : '') + '...';
-    grunt.verbose.write(msg);
-
     if (results.length === 0) {
       // Success!
       grunt.verbose.ok();
@@ -102,12 +99,16 @@ exports.init = function(grunt) {
     var tabstr = getTabStr(options);
     var placeholderregex = new RegExp(tabstr, 'g');
 
-    // Something went wrong.
-    grunt.verbose.or.write(msg);
-    grunt.log.error();
-
     // Iterate over all errors.
     results.forEach(function(result) {
+      // Display the defending file
+      var msg = 'Linting' + (result.file ? ' ' + result.file : '') + '...';
+      grunt.verbose.write(msg);
+
+      // Something went wrong.
+      grunt.verbose.or.write(msg);
+      grunt.log.error();
+
       var e = result.error;
       // Sometimes there's no error object.
       if (!e) { return; }

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -62,6 +62,20 @@ exports.jshint = {
       test.done();
     });
   },
+  defaultReporterErrors: function(test) {
+    test.expect(3);
+    grunt.log.muted = false;
+    var files = [path.join(fixtures, 'nodemodule.js'), path.join(fixtures, 'missingsemicolon.js')];
+    var options = {};
+    stdoutEqual(function() {
+      jshint.lint(files, options, function(results, data) {});
+    }, function(result) {
+      test.ok(jshint.usingGruntReporter, 'Should be using the default grunt reporter.');
+      test.ok(result.match(/nodemodule\.js\.\.\.ERROR/g).length === 2, 'Should have reported nodemodule.js once per error.');
+      test.ok(result.match(/missingsemicolon\.js\.\.\.ERROR/g).length === 1, 'Should have reported missingsemicolon.js once per error.');
+      test.done();
+    });
+  },
   alternateReporter: function(test) {
     test.expect(2);
     var files = [path.join(fixtures, 'nodemodule.js')];


### PR DESCRIPTION
This pull request address #57. 

Essentially the reported assumed a single file to be passed in. This was the old behaviour.

Now it prints the actual offending filename with the error. See #57 for screenshots.
