### PR TITLE
Add option to fail the task whilst generating a report file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Default value: `null`
 
 Specify a filepath to output the results of a reporter. If `reporterOutput` is specified then all output will be written to the given filepath instead of printed to stdout.
 
+
+#### failWithReporterOutput
+Type: `Boolean`
+Default value: `false`
+
+Allows you to specify if linting errors should fail the build task, along with outputting the results to a report file. 
+
 ### Usage examples
 
 #### Wildcards

--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -20,6 +20,7 @@ module.exports = function(grunt) {
     var options = this.options({
       force: false,
       reporterOutput: null,
+      failWithReporterOutput: false
     });
 
     // Report JSHint errors but dont fail the task
@@ -29,6 +30,9 @@ module.exports = function(grunt) {
     // Whether to output the report to a file
     var reporterOutput = options.reporterOutput;
     delete options.reporterOutput;
+
+    var failWithReporterOutput = options.failWithReporterOutput;
+    delete options.failWithReporterOutput;
 
     // Hook into stdout to capture report
     var output = '';
@@ -62,7 +66,9 @@ module.exports = function(grunt) {
         }
         grunt.file.write(reporterOutput, output);
         grunt.log.ok('Report "' + reporterOutput + '" created.');
-        failed = 0;
+        if(!failWithReporterOutput) {
+          failed = 0;
+        }
       }
 
       done(failed);


### PR DESCRIPTION
I'm using Grunt with TeamCity to build our JS sources. I'd like jshint failures to fail the grunt build, whilst outputting the jslint style xml report for TeamCity. 

As the plugin stands, the task will always succeed when the results are written to a report file. I've added an option to control this behaviour. 
