### PR TITLE
Bump JSHint to 2.1.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~2.0.1"
+    "jshint": "~2.1.3"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.1.2",


### PR DESCRIPTION
JSHint has kicked into a faster release cadence, so they've already release a minor version bump.
