### PR TITLE
Update jshint dependency to ~2.1.0. Fixes GH-61

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~2.0.1"
+    "jshint": "~2.1.0"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.1.2",


### PR DESCRIPTION
This pull request updates the jshint dependency to ~2.1.0. Since the jshint team are moving faster now it's better to just lock to a minor version than push out a release for each patch.

Thoughts @shama?
