### PR TITLE
Allow single line comments in jshintrc file

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,13 +1,13 @@
 {
-  "curly": true,
-  "eqeqeq": true,
-  "immed": true,
-  "latedef": true,
-  "newcap": true,
-  "noarg": true,
-  "sub": true,
-  "undef": true,
-  "boss": true,
-  "eqnull": true,
-  "node": true
+  "curly"         : true,     // true: Require {} for every new block or scope
+  "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+  "immed"         : true,     // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+  "latedef"       : true,     // true: Require variables/functions to be defined before being used
+  "newcap"        : true,     // true: Require capitalization of all constructor functions e.g. `new F()`
+  "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+  "sub"           : true,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+  "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+  "boss"          : true,     // true: Tolerate assignments where comparisons would be expected
+  "eqnull"        : true,     // true: Tolerate use of `== null`
+  "node"          : true     // Node.js
 }

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -180,8 +180,8 @@ exports.init = function(grunt) {
 
     // Read JSHint options from a specified jshintrc file.
     if (options.jshintrc) {
-      options = grunt.file.readJSON(options.jshintrc);
-      delete options.jshintrc;
+      options = grunt.file.read(options.jshintrc);
+      options = JSON.parse(options.replace(/\/\/.*/g, ''));
     }
 
     // Enable/disable debugging if option explicitly set.


### PR DESCRIPTION
The jshintrc file found at jshint/jshint/example/.jshintrc has comments. This should allow comments.
