### PR TITLE
Update to jshint@2.1.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.6.3:
+  date: 2013-08-11
+  changes:
+    - Update to jshint 2.1.9.
 v0.6.2:
   date: 2013-07-29
   changes:

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ grunt.initConfig({
 
 ## Release History
 
+ * 2013-08-11   v0.6.3   Update to jshint 2.1.9.
  * 2013-07-29   v0.6.2   Update to jshint 2.1.7.
  * 2013-07-27   v0.6.1   Peg jshint to 2.1.4 until breaking changes in 2.1.5 are fixed.
  * 2013-06-02   v0.6.0   Dont always succeed the task when using a custom reporter. Bump jshint to 2.1.3.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-jshint",
   "description": "Validate files with JSHint.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "homepage": "https://github.com/gruntjs/grunt-contrib-jshint",
   "author": {
     "name": "Grunt Team",
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~2.1.7"
+    "jshint": "~2.1.9"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.1.2",


### PR DESCRIPTION
Using jshint@2.1.9 allows for merging `.jshintrc` into npm's `package.json`.

All tests ran successfully against 2.1.9.
