### PR TITLE
Allow comments in .jshintrc with jshintcli.loadConfig()

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,13 +1,13 @@
 {
-  "curly": true,
-  "eqeqeq": true,
-  "immed": true,
-  "latedef": true,
-  "newcap": true,
-  "noarg": true,
-  "sub": true,
-  "undef": true,
-  "boss": true,
-  "eqnull": true,
-  "node": true
+  "curly": true,    // true: Require {} for every new block or scope
+  "eqeqeq": true,   // true: Require triple equals (===) for comparison
+  "immed": true,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+  "latedef": true,  // true: Require variables/functions to be defined before being used
+  "newcap": true,   // true: Require capitalization of all constructor functions e.g. `new F()`
+  "noarg": true,    // true: Prohibit use of `arguments.caller` and `arguments.callee`
+  "sub": true,      // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+  "undef": true,    // true: Require all non-global variables to be declared (prevents global leaks)
+  "boss": true,     // true: Tolerate assignments where comparisons would be expected
+  "eqnull": true,   // true: Tolerate use of `== null`
+  "node": true      // Node.js
 }

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -186,7 +186,7 @@ exports.init = function(grunt) {
 
     // Read JSHint options from a specified jshintrc file.
     if (options.jshintrc) {
-      options = grunt.file.readJSON(options.jshintrc);
+      options = jshintcli.loadConfig(options.jshintrc);
       delete options.jshintrc;
     }
 


### PR DESCRIPTION
jshint has exposed the loadConfig method since v2.1.5.

Related:
- https://github.com/gruntjs/grunt-contrib-jshint/issues/2
- https://github.com/gruntjs/grunt-contrib-jshint/issues/79
- https://github.com/gruntjs/grunt-contrib-jshint/pull/80#issuecomment-21017860
- https://github.com/jshint/jshint/issues/741
