### PR TITLE
Thus it is possible to override options of .jshintrc file

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -186,7 +186,7 @@ exports.init = function(grunt) {
 
     // Read JSHint options from a specified jshintrc file.
     if (options.jshintrc) {
-      options = jshintcli.loadConfig(options.jshintrc);
+      options = grunt.util._.defaults(options, jshintcli.loadConfig(options.jshintrc));
       delete options.jshintrc;
     }
 


### PR DESCRIPTION
Look the issue: https://github.com/gruntjs/grunt-contrib-jshint/issues/90
