### PR TITLE
Add customisable reporterOutputMessage for when report done.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Default value: `null`
 
 Specify a filepath to output the results of a reporter. If `reporterOutput` is specified then all output will be written to the given filepath instead of printed to stdout.
 
+#### reporterOutputMessage
+Type: `String`
+Default value: `Report <%= grunt.task.current.options.data.reporterOutput %> created.`
+
+Specify a custom message to be printed when the report is done. This is for example useful for hooking into CI report importers such as [Teamcity's](http://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ImportingXMLReports)
+
 ### Usage examples
 
 #### Wildcards

--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -20,6 +20,7 @@ module.exports = function(grunt) {
     var options = this.options({
       force: false,
       reporterOutput: null,
+      reporterOutputMessage: 'Report <%= grunt.task.current.options.data.reporterOutput %> created.'
     });
 
     // log (verbose) options before hooking in the reporter
@@ -32,6 +33,11 @@ module.exports = function(grunt) {
     // Whether to output the report to a file
     var reporterOutput = options.reporterOutput;
     delete options.reporterOutput;
+
+    // The message to output when the report is written to file
+    // Can be used to customise done message for CI report importers such as Teamcity's
+    var reporterOutputMessage = options.reporterOutputMessage;
+    delete options.reporterOutputMessage;
 
     // Hook into stdout to capture report
     var output = '';
@@ -64,7 +70,7 @@ module.exports = function(grunt) {
           grunt.file.mkdir(destDir);
         }
         grunt.file.write(reporterOutput, output);
-        grunt.log.ok('Report "' + reporterOutput + '" created.');
+        grunt.log.ok(reporterOutputMessage);
       }
 
       done(failed);


### PR DESCRIPTION
Let the user customise the message to be printed when the report is done. This is for example useful for hooking into CI report importers such as [Teamcity's](http://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ImportingXMLReports)

I'm using it like so:

``` javascript
jshint: {
  teamcity: {    
    options: {
      reporter: 'checkstyle',
      reporterOutput: '.jshint.checkstyle.xml',
      reporterOutputMessage: "##teamcity[importData type='<%= jshint.teamcity.options.reporter %>' path='<%= jshint.teamcity.options.reporterOutput %>']"
    }
  }
}
```

I wasn't sure how to write a test for this change since it's not related to the jshint lib integration which is the only one being tested as far as I can see.

AFAIK without forcing it's impossible to print a statement after a certain task fails, therefore we need this integration IMHO.
