### PR TITLE
Fix `Writing your own JSHint reporter.` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Default value: `null`
 
 Allows you to modify this plugins output. By default it will use a built-in Grunt reporter. Set the path to your own custom reporter or to one of the built-in JSHint reporters: `jslint` or `checkstyle`.
 
-See also: [Writing your own JSHint reporter.](http://jshint.com/docs/reporter/)
+See also: [Writing your own JSHint reporter.](http://jshint.com/docs/reporters/)
 
 #### reporterOutput
 Type: `String`


### PR DESCRIPTION
They changed the path, the old path gives a 404. This corrects the path `Writing your own JSHint reporter.`.
