### PR TITLE
Added the ability to specify `true` for the `jshintrc` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ Default value: `null`
 A map of global variables, with keys as names and a boolean value to determine if they are assignable. This is not a standard JSHint option, but is passed into the `JSHINT` function as its third argument. See the [JSHint documentation][] for more information.
 
 #### jshintrc
-Type: `String`
+Type: `String` or `true`
 Default value: `null`
 
-If this filename is specified, options and globals defined therein will be used. The `jshintrc` file must be valid JSON and looks something like this:
+If set to `true`, no config will be sent to jshint and jshint will search for `.jshintrc` files relative to the flies being linted.
+
+If a filename is specified, options and globals defined therein will be used. The `jshintrc` file must be valid JSON and looks something like this:
 
 ```json
 {

--- a/docs/jshint-options.md
+++ b/docs/jshint-options.md
@@ -14,10 +14,12 @@ Default value: `null`
 A map of global variables, with keys as names and a boolean value to determine if they are assignable. This is not a standard JSHint option, but is passed into the `JSHINT` function as its third argument. See the [JSHint documentation][] for more information.
 
 ## jshintrc
-Type: `String`
+Type: `String` or `true`
 Default value: `null`
 
-If this filename is specified, options and globals defined therein will be used. The `jshintrc` file must be valid JSON and looks something like this:
+If set to `true`, no config will be sent to jshint and jshint will search for `.jshintrc` files relative to the flies being linted.
+
+If a filename is specified, options and globals defined therein will be used. The `jshintrc` file must be valid JSON and looks something like this:
 
 ```json
 {

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -184,22 +184,24 @@ exports.init = function(grunt) {
       }
     });
 
-    // Read JSHint options from a specified jshintrc file.
-    if (options.jshintrc) {
-      options = jshintcli.loadConfig(options.jshintrc);
-      delete options.jshintrc;
-    }
-
-    // Enable/disable debugging if option explicitly set.
-    if (grunt.option('debug') !== undefined) {
-      options.devel = options.debug = grunt.option('debug');
-      // Tweak a few things.
-      if (grunt.option('debug')) {
-        options.maxerr = Infinity;
+    if (options.jshintrc === true) {
+      // let jshint find the options itself
+      delete cliOptions.config;
+    } else if (options.jshintrc) {
+      // Read JSHint options from a specified jshintrc file.
+      cliOptions.config = jshintcli.loadConfig(options.jshintrc);
+    } else {
+      // Enable/disable debugging if option explicitly set.
+      if (grunt.option('debug') !== undefined) {
+        options.devel = options.debug = grunt.option('debug');
+        // Tweak a few things.
+        if (grunt.option('debug')) {
+          options.maxerr = Infinity;
+        }
       }
+      // pass all of the remaining options directly to jshint
+      cliOptions.config = options;
     }
-
-    cliOptions.config = options;
 
     // Run JSHint on all file and collect results/data
     var allResults = [];

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -49,6 +49,17 @@ exports.jshint = {
       test.done();
     });
   },
+  passTheJshintrcBuck: function(test) {
+    test.expect(1);
+    var files = [path.join(fixtures, 'nodemodule.js')];
+    var options = {
+      jshintrc: true
+    };
+    jshint.lint(files, options, function(results, data) {
+      test.ok(results.length === 0, 'Should not have reported any errors, .jshintrc must not have been found');
+      test.done();
+    });
+  },
   defaultReporter: function(test) {
     test.expect(2);
     grunt.log.muted = false;


### PR DESCRIPTION
I personally prefer to store my config in `.jshintrc` files so that my config can be shared between grunt and my IDE. As my project becomes a bit more complex, and different directories are using different rc-files, I thought it would be nice to have the option to just defer rc-file lookup to jshint allowing me to "set and forget" the jshint config in my Gruntfile. 

It also presents identical results when I run `grunt jshint`, `jshint .`, or check a single file against jshint in my IDE.
