### PR TITLE
0.6.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.6.5:
+  date: 2013-09-21
+  changes:
+    - jshint updated to 2.3.0.
 v0.6.4:
   date: 2013-08-29
   changes:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-jshint",
   "description": "Validate files with JSHint.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "homepage": "https://github.com/gruntjs/grunt-contrib-jshint",
   "author": {
     "name": "Grunt Team",
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~2.1.10"
+    "jshint": "~2.3.0"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.1.2",


### PR DESCRIPTION
- jshint update to 2.3.0

Mostly jshint bug fixes, most noticeably switch indentation fixed.
