### PR TITLE
Update dependencies & devDependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# grunt-contrib-jshint v0.6.4 [![Build Status](https://travis-ci.org/gruntjs/grunt-contrib-jshint.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-jshint)
+# grunt-contrib-jshint v0.6.5-pre [![Build Status](https://travis-ci.org/gruntjs/grunt-contrib-jshint.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-jshint)
 
 > Validate files with JSHint.
 
 
 
 ## Getting Started
-This plugin requires Grunt `~0.4.0`
+This plugin requires Grunt `~0.4.1`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -228,4 +228,4 @@ grunt.initConfig({
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Thu Aug 29 2013 08:46:48.*
+*This file was generated on Wed Oct 23 2013 18:12:54.*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-jshint",
   "description": "Validate files with JSHint.",
-  "version": "0.6.4",
+  "version": "0.6.5-pre",
   "homepage": "https://github.com/gruntjs/grunt-contrib-jshint",
   "author": {
     "name": "Grunt Team",
@@ -27,15 +27,15 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~2.1.10"
+    "jshint": "~2.3.0"
   },
   "devDependencies": {
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-nodeunit": "~0.2.2",
     "grunt-contrib-internal": "~0.4.6",
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.1"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
In particular, one of multiple gains of updating jsHint is that
the issue https://github.com/jshint/jshint/issues/935 was closed
making the `indent` option work much better.
