### PR TITLE
Only report filename once as opposed to once per error. Fixes GH-117

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -101,15 +101,20 @@ exports.init = function(grunt) {
     var tabstr = getTabStr(options);
     var placeholderregex = new RegExp(tabstr, 'g');
 
+    var lastfile = null;
     // Iterate over all errors.
     results.forEach(function(result) {
       // Display the defending file
       var msg = 'Linting' + (result.file ? ' ' + result.file : '') + ' ...';
       grunt.verbose.write(msg);
 
-      // Something went wrong.
-      grunt.verbose.or.write(msg);
-      grunt.log.error();
+      // Something went wrong.  Only print linting/file name and error msg once
+      // per file - when the first err/warn is found.
+      if(result.file !== lastfile) {
+        grunt.verbose.or.write(msg);
+        grunt.log.error();
+      }
+      lastfile = result.file;
 
       var e = result.error;
       // Sometimes there's no error object.

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -82,8 +82,8 @@ exports.jshint = {
       jshint.lint(files, options, function(results, data) {});
     }, function(result) {
       test.ok(jshint.usingGruntReporter, 'Should be using the default grunt reporter.');
-      test.ok(result.match(/nodemodule\.js\s\.\.\.ERROR/g).length === 2, 'Should have reported nodemodule.js once per error.');
-      test.ok(result.match(/missingsemicolon\.js\s\.\.\.ERROR/g).length === 1, 'Should have reported missingsemicolon.js once per error.');
+      test.ok(result.match(/nodemodule\.js\s\.\.\.ERROR/g).length === 1, 'Should have reported nodemodule.js only once.');
+      test.ok(result.match(/missingsemicolon\.js\s\.\.\.ERROR/g).length === 1, 'Should have reported missingsemicolon.js only once.');
       test.done();
     });
   },


### PR DESCRIPTION
The "Linting filename ... ERROR" message is now printed once per file, rather than once per error/warning.  Fixes GH-117.

In other words, instead of 

  Linting dir/file1.js ...ERROR
  [L1:C2] E001: Foo
  invalidCodeHere
  Linting dir/file1.js ...ERROR
  [L2:C1] E002: Bar
  invalidCodeHere

You would now see

  Linting dir/file1.js ...ERROR
  [L1:C2] E001: Foo
  invalidCodeHere
  [L2:C1] E002: Bar
  invalidCodeHere
