### PR TITLE
Added main attribute in package.json to allow for harmless requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
   },
   "keywords": [
     "gruntplugin"
-  ]
+  ],
+  "main": "tasks/jshint.js"
 }


### PR DESCRIPTION
Some node projects iterate through their node_modules directory and attempt to require every module based on its directory name. In the case of grunt-contrib-jshint, this causes an error because it has no main property in its package.json file. I suggest adding this property as it does not cause harm and some node projects may actually want to require it.
