### PR TITLE
Support extract option

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -180,6 +180,12 @@ exports.init = function(grunt) {
       delete options.ignores;
     }
 
+    // Option to extract JS from HTML file
+    if (options.extract) {
+      cliOptions.extract = options.extract;
+      delete options.extract;
+    }
+
     // Select a reporter to use
     var reporter = exports.selectReporter(options);
 

--- a/test/fixtures/extract.html
+++ b/test/fixtures/extract.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+var missingsemicolon = true
+</script>
+</body>
+</html>

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -148,5 +148,17 @@ exports.jshint = {
       test.equal(reporterCallCount, 1, 'Should have called the reporter once.');
       test.done();
     });
+  },
+  extractOption: function(test) {
+    test.expect(2);
+    var files = [path.join(fixtures, 'extract.html')];
+    var options = {
+      extract: 'always'
+    };
+    jshint.lint(files, options, function(results, data) {
+      test.equal(results[0].error.reason, 'Missing semicolon.', 'Should reporter a missing semicolon.');
+      test.equal(results.length, 1, 'Should report only one.');
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
Support [**extract** option](http://www.jshint.com/blog/new-in-jshint-dec-2013/) which has been introduced at jshint 2.4.0.

After this change, we can specify extract option such like this:

``` js
// Project configuration.
grunt.initConfig({
  jshint: {
    options: {
        extract: 'auto'
    }
  }
});
```
