### PR TITLE
Enhancing the readability of the console output.

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -47,9 +47,19 @@ module.exports = function(grunt) {
       if (results.length > 0) {
         // Fail task if errors were logged except if force was set.
         failed = force;
+        if (jshint.usingGruntReporter === true) {
+
+          var numErrors = grunt.util._.reduce(results,function(memo,result){
+            return memo + (result.error ? 1 : 0);
+          },0);
+
+          var numFiles = data.length;
+          grunt.log.error(numErrors + ' ' + grunt.util.pluralize(numErrors,'error/errors') + ' in ' +
+                          numFiles + ' ' + grunt.util.pluralize(numFiles,'file/files'));
+        }
       } else {
         if (jshint.usingGruntReporter === true && data.length > 0) {
-          grunt.log.ok(data.length + ' file' + (data.length === 1 ? '' : 's') + ' lint free.');
+          grunt.log.ok(data.length + ' ' + grunt.util.pluralize(data.length,'file/files') + ' lint free.');
         }
       }
 

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -69,7 +69,7 @@ exports.jshint = {
       jshint.lint(files, options, function(results, data) {});
     }, function(result) {
       test.ok(jshint.usingGruntReporter, 'Should be using the default grunt reporter.');
-      test.ok(result.indexOf('[L3:C1] W117: \'module\' is not defined.') !== -1, 'Should have reported errors with the default grunt reporter.');
+      test.ok(result.indexOf('\'module\' is not defined.') !== -1, 'Should have reported errors with the default grunt reporter.');
       test.done();
     });
   },
@@ -82,8 +82,8 @@ exports.jshint = {
       jshint.lint(files, options, function(results, data) {});
     }, function(result) {
       test.ok(jshint.usingGruntReporter, 'Should be using the default grunt reporter.');
-      test.ok(result.match(/nodemodule\.js\s\.\.\.ERROR/g).length === 1, 'Should have reported nodemodule.js only once.');
-      test.ok(result.match(/missingsemicolon\.js\s\.\.\.ERROR/g).length === 1, 'Should have reported missingsemicolon.js only once.');
+      test.ok(result.match(/nodemodule\.js/g).length === 1, 'Should have reported nodemodule.js only once.');
+      test.ok(result.match(/missingsemicolon\.js/g).length === 1, 'Should have reported missingsemicolon.js only once.');
       test.done();
     });
   },


### PR DESCRIPTION
The PR updates the console output to match the proposed idea in #31.  

Before:

```
Running "jshint:main" (jshint) task
Linting partial/my-partial/my-partial-spec.js ...ERROR
[L8:C7] W117: 'scope' is not defined.
      scope = $rootScope.$new();
[L9:C52] W117: 'scope' is not defined.
      ctrl = $controller('MyPartialCtrl', {$scope: scope});
[L14:C16] W117: 'scope' is not defined.
    expect(scope.test).toEqual("hik");
```

After:

```
Running "jshint:main" (jshint) task

   partial/my-partial/my-partial-spec.js
      8 |      scope = $rootScope.$new();
               ^ 'scope' is not defined.
      9 |      ctrl = $controller('MyPartialCtrl', {$scope: scope});
                                                            ^ 'scope' is not defined.
     14 |        expect(scope.test).toEqual("hik");
                        ^ 'scope' is not defined.

>> 3 errors in 10 files
```

While writing the changes, I noticed that the character positions weren't lining up correctly due to the previous getTabStr function no longer working as expected.  I'm guessing an upgrade in the underlying jshint broke the technique used there.  I ended up using a different approach (grab the indent property and replace the tabs with that many spaces).  
