### PR TITLE
Update jshint from 2.4.0 to 2.4.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~2.4.0"
+    "jshint": "~2.4.3"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.2.2",


### PR DESCRIPTION
In jshint 2.4.0, there is a conflict between the `esnext` and `undef` options:

``` javascript
// jshint undef: true, esnext: true
var doubler = n => n * 2;
```

In this example, `doubler` is a valid JS function, equivalent to `function(n) {return n * 2;}`, but the `undef` validation emits an error. This conflict is resolved in jshint 2.4.3.

Based on [the most recent jshint update pull request](https://github.com/gruntjs/grunt-contrib-jshint/pull/128), I wasn't sure how to structure this one. I'd welcome your advice!
