### PR TITLE
Remove grunt.util.hooker

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~2.4.0"
+    "jshint": "~2.4.0",
+    "hooker": "~0.2.3"
   },
   "devDependencies": {
     "grunt-contrib-nodeunit": "~0.3.1",

--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -11,6 +11,7 @@
 module.exports = function(grunt) {
 
   var path = require('path');
+  var hooker = require('hooker');
   var jshint = require('./lib/jshint').init(grunt);
 
   grunt.registerMultiTask('jshint', 'Validate files with JSHint.', function() {
@@ -33,10 +34,10 @@ module.exports = function(grunt) {
     // Hook into stdout to capture report
     var output = '';
     if (reporterOutput) {
-      grunt.util.hooker.hook(process.stdout, 'write', {
+      hooker.hook(process.stdout, 'write', {
         pre: function(out) {
           output += out;
-          return grunt.util.hooker.preempt();
+          return hooker.preempt();
         }
       });
     }
@@ -54,7 +55,7 @@ module.exports = function(grunt) {
 
       // Write the output of the reporter if wanted
       if (reporterOutput) {
-        grunt.util.hooker.unhook(process.stdout, 'write');
+        hooker.unhook(process.stdout, 'write');
         reporterOutput = grunt.template.process(reporterOutput);
         var destDir = path.dirname(reporterOutput);
         if (!grunt.file.exists(destDir)) {

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -2,12 +2,12 @@
 
 var path = require('path');
 var grunt = require('grunt');
+var hooker = require('hooker');
 var jshint = require('../tasks/lib/jshint').init(grunt);
 
 var fixtures = path.join(__dirname, 'fixtures');
 
 // Helper for testing stdout
-var hooker = grunt.util.hooker;
 var stdoutEqual = function(callback, done) {
   var actual = '';
   // Hook process.stdout.write


### PR DESCRIPTION
Because [grunt.util.hooker](http://gruntjs.com/api/grunt.util#grunt.util.hooker) is [deprecated](http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released).
