### PR TITLE
Update jshint version to 2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jshint": "~2.4.0",
+    "jshint": "~2.4.4",
     "hooker": "~0.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates jshint to version 2.4.4.

Quite a bit of new features, for my part the ES6-support is the most crucial.

Not sure how you'd like the CHANGELOG updated as well, or if you only do that on releases =)
