### PR TITLE
passed jshint options to external reporter

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -187,7 +187,7 @@ exports.init = function(grunt) {
     var allData = [];
     cliOptions.args = files;
     cliOptions.reporter = function(results, data) {
-      reporter(results, data);
+      reporter(results, data, options);
       allResults = allResults.concat(results);
       allData = allData.concat(data);
     };


### PR DESCRIPTION
Fixed a bug. Options from jshint were not passed into the reporter. For example if I used verbose mode I couldn't see the error num in jshint-stylish reporter.
