### PR TITLE
Allow for per-task ignores settings.

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -23,6 +23,11 @@ module.exports = function(grunt) {
       reporterOutput: null,
     });
 
+    //Put any ignores into our options to pass to jshint#lint.
+    if (this.data.ignores && this.data.ignores.length > 0) {
+      //We do a shallow clone here...though not strictly necessary.
+      options.ignores = this.data.ignores.slice();
+    }
     // Report JSHint errors but dont fail the task
     var force = options.force;
     delete options.force;


### PR DESCRIPTION
Feels like we should be able to do something like this in a Grunfile.js:

``` javascript
        jshint: {                                                              
            options: _.extend(directives.jshint, {                             
                reporter: require('jshint-stylish'),                           
                //ignores: [                                                   
                //    '**/node_modules/**'                                     
                //]                                                            
            }),                                                                
            all: {                                                             
                src: [                                                         
                    'Gruntfile.js',                                            
                    '<%=yeoman.app %>/**/*.js'//,                              
                ],                                                             
                ignores: [                                                     
                    '**/node_modules/**'                                       
                ]                                                                                                                             
            },                                                                 
            foo: {                                                             
                src: [                                                         
                    'Gruntfile.js',                                            
                    '<%=yeoman.app %>/**/*.js'//,                              
                ]                                                              
            }                                                                  

        },                           
```

This patch allows for per task ignores to be passed into grunt-contrib-jshint task -- which I kind of feel is a bit cleaner to read and gives a good utility in allowing per task overwriting of the project .jshintignore file.
