### PR TITLE
feat(options) added ignoreFromGitIgnore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ Default: `null`
 A list of files and dirs to ignore. This will override your `.jshintignore` file if set and does not merge.
 
 
+#### ignoreFromGitIgnore
+
+Type: `Boolean`  
+Default: `false`
+
+Set `ignoreFromGitIgnore` to `true` to make JSHint to also ignore the files ignored by `.gitignore`. This way the `.gitignore` acts like the  `.jshintignore`.
+
+
 #### force
 
 Type: `Boolean`  

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -147,6 +147,36 @@ exports.init = function(grunt) {
       delete options.ignores;
     }
 
+    // A flag that indicates whether jshint should ignore
+    // the files from .gitignore too
+    if (options.ignoreFromGitIgnore) {
+      var gitignorePath = './.gitignore',
+          toIgnore = [];
+
+      // if the current project has a .gitignore file
+      if(grunt.file.exists(gitignorePath)) {
+        // an array of all the stated files from .gitignore
+        toIgnore = grunt.file.read(gitignorePath)
+                    .replace(/(\s|\t|\n)+/g, ' ')
+                    .trim()
+                    .split(/\s/g);
+      }
+
+      // if we have something to ignore
+      if(toIgnore.length) {
+        // if we didn't ignore anything before
+        if(!cliOptions.ignores) {
+          cliOptions.ignores = toIgnore;
+        } else {
+          // @todo: remove duplicate entries
+          cliOptions.ignores = cliOptions.ignores.concat(toIgnore);
+        }
+      }
+
+      // remove this "bad" option from the options object.
+      delete options.ignoreFromGitIgnore;
+    }
+
     // Option to extract JS from HTML file
     if (options.extract) {
       cliOptions.extract = options.extract;


### PR DESCRIPTION
I know jshint ignores files listed in the _.jshintignore_ file, but you don't need to test files that you don't own and version (which are ignored by git), so I added an option (called `ignoreFromGitIgnore`) that makes jshint ignore the files from `.gitignore` too. 
