### PR TITLE
revert part of a previous merge which removes the Wnnn numbers showing so you could pick them up quickly

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -114,7 +114,7 @@ exports.init = function(grunt) {
 
         grunt.log.writeln((pad(e.line.toString(),7) + ' |') + evidence.grey);
         grunt.log.write(grunt.util.repeat(9,' ') + grunt.util.repeat(e.character -1,' ') + '^ ');
-        grunt.verbose.write('[' + e.code + '] ');
+        grunt.log.write('[' + e.code + '] ');
         grunt.log.writeln(e.reason);
 
       } else {


### PR DESCRIPTION
revert part of the 'cleanup' which removed this feature from grunt-contrib-jshint: *always* print the JSHint W/nnn/ error code (which speeds up the process of picking these up and adding specific error skip/ignore clauses in the JSHint config and/or sourcecode)

(And yeah, they are visible in 'grunt --verbose' mode, but that clutters the output no end for larger grunt runs.)