### PR TITLE
Removing trailing commas to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,19 +173,19 @@ grunt.initConfig({
       browser: true,
       globals: {
         jQuery: true
-      },
+      }
     },
     uses_defaults: ['dir1/**/*.js', 'dir2/**/*.js'],
     with_overrides: {
       options: {
         curly: false,
-        undef: true,
+        undef: true
       },
       files: {
         src: ['dir3/**/*.js', 'dir4/**/*.js']
-      },
+      }
     }
-  },
+  }
 });
 ```
 
@@ -204,11 +204,11 @@ grunt.initConfig({
   jshint: {
     ignore_warning: {
       options: {
-        '-W015': true,
+        '-W015': true
       },
-      src: ['**/*.js'],
-    },
-  },
+      src: ['**/*.js']
+    }
+  }
 });
 ```
 


### PR DESCRIPTION
I noticed that in the README documentation example code, there were some unnecessary trailing commas. I removed them so that people won't be confused.
