### PR TITLE
(Test only) grunt doesn't warn when the property of an undeclared variable is accessed

### DIFF
--- a/test/fixtures/undefinedaccess.js
+++ b/test/fixtures/undefinedaccess.js
@@ -1,0 +1,1 @@
+undefinedObject.property = 5;

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -161,5 +161,12 @@ exports.jshint = {
       test.equal(results.length, 1, 'Should report only one.');
       test.done();
     });
+  },
+  undefinedAccess: function(test) {
+    var files = [path.join(fixtures, 'undefinedaccess.js')];
+    jshint.lint(files, {}, function(results, data) {
+      test.equal(results.length, 1, 'Should report only one.');
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
The following code in an empty file make jshint succeed when it shouldn't:

```javascript
undefinedObject.property = 5;
```

In jshint.com it fails:

![image](https://cloud.githubusercontent.com/assets/835857/5811105/3b3d1860-a038-11e4-8b55-84e99e81cb21.png)

I managed to create a failing test to reproduce the issue. I am not sure of the problem is here or upstream, but I spotted the problem when using Grunt so I am reporting here.