### PR TITLE
Define additional custom globals in Gruntfile.js when using a jshintrc file

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -175,6 +175,16 @@ exports.init = function(grunt) {
     } else if (options.jshintrc) {
       // Read JSHint options from a specified jshintrc file.
       cliOptions.config = jshintcli.loadConfig(options.jshintrc);
+      // merge globals setting from config into the globals defined in jshintrc file
+      if (options.globals) {
+        if(!cliOptions.config.globals) {
+          cliOptions.config.globals = {};
+        }
+        for (var key in options.globals) {
+          cliOptions.config.globals[key] = options.globals[key];
+        }
+        delete options.globals;
+      }
     } else {
       // Enable/disable debugging if option explicitly set.
       if (grunt.option('debug') !== undefined) {

--- a/test/fixtures/globals.js
+++ b/test/fixtures/globals.js
@@ -1,0 +1,1 @@
+MyApp.log('test');

--- a/test/fixtures/globals_jshintrc.js
+++ b/test/fixtures/globals_jshintrc.js
@@ -1,0 +1,3 @@
+{
+    "undef": true  // true: Require all non-global variables to be declared (prevents global leaks)
+}

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -161,5 +161,19 @@ exports.jshint = {
       test.equal(results.length, 1, 'Should report only one.');
       test.done();
     });
+  },
+  mergeGlobalsConfigWithJshintrc: function(test) {
+    test.expect(1);
+    var files = [path.join(fixtures, 'globals.js')];
+    var options = {
+      jshintrc: path.join(fixtures, 'globals_jshintrc.js'),
+      globals: {
+        'MyApp': true
+      }
+    };
+    jshint.lint(files, options, function(results, data) {
+      test.ok(results.length === 0, 'Should not have reported any errors, custom globals setting must not have been merged with jshintrc settings.');
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
We deal with a lot of different frameworks and libraries in our daily work and did not want to maintain different .jshintrc files for different projects. This PR allows to define a globals setting in the Gruntfile.js which then gets merged into the config read from the defined .jshintrc file before running jshint.
