### PR TITLE
ensure options to path.resolve are strings

### DIFF
--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -46,7 +46,7 @@ exports.init = function(grunt) {
 
     // Custom reporter
     case options.reporter !== undefined:
-      options.reporter = path.resolve(process.cwd(), options.reporter);
+      options.reporter = path.resolve(process.cwd(), options.reporter.toString());
     }
 
     var reporter;


### PR DESCRIPTION
The arguments to path.resolve must be strings. Invoke toString on the option to ensure it's given a string.

If the option is already a string, nothing changes. However, invoking toString makes writing custom reporters *much* nicer.

As it stands now, the jshint cli expects a path to a script that exports an object with a `reporter` function. This task expects the same thing. This means that a custom reporter can optimize itself to be required via the jshint cli *OR* this grunt task; but not both.

**optimized for jshint cli**
By ensuring that main is the reporter object itself, it is easy to require the reporter via the cli: `jshint --reporter $(npm root)/my-reporter`.
But this makes requiring the reporter via the task more verbose: `{ reporter: 'node_modules/my-reporter' }`.

**optimized for jshint grunt task**
By ensuring the main script returns the path to the real reporter as a string, it is easy to configure the reporter for grunt: `{ reporter: require('my-reporter') }`.
But this makes require the reporter via the cli more verbose: `jshint --reporter $(npm root)/my-reporter/actual-reporter-script`

With this single `toString` change, a custom reporter can now be optimized for *both* the grunt task and the jshint cli.

``` javascript
// custom-reporter/index.js

module.exports = {
  reporter: function(){
    //...
  },
  toString: function(){
    return __filename;
  }
};
```

Then the custom reporter can be easily required directly for the CLI: `jshint --reporter $(npm root)/custom-reporter` or for the grunt task: `{ reporter: require('custom-reporter') }`