### PR TITLE
fix default value of option reporter

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -19,7 +19,8 @@ module.exports = function(grunt) {
 
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-      force: false
+      force: false,
+      reporter: null
     });
 
     // Report JSHint errors but dont fail the task

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -45,7 +45,7 @@ exports.init = function(grunt) {
       break;
 
     // Custom reporter
-    case options.reporter !== undefined:
+    case options.reporter !== null:
       options.reporter = path.resolve(process.cwd(), options.reporter.toString());
     }
 

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -45,7 +45,7 @@ exports.init = function(grunt) {
       break;
 
     // Custom reporter
-    case options.reporter !== null:
+    case options.reporter !== null && options.reporter !== undefined:
       options.reporter = path.resolve(process.cwd(), options.reporter.toString());
     }
 


### PR DESCRIPTION
use ```null``` like defined in documentation instead of ```undefined```

To specify options manually for ci output I add an option to grunt:

```grunt jshint --integration``` for using grunt task with jenkins
```grunt jshint``` for using grunt task locally

```
module.exports = function (grunt) {
    'use strict';

    var isIntegration = grunt.option('integration') ? true : false;
    grunt.initConfig({
         jshint: {
            dependency: {
                src: [
                    'gruntfile.js'
                ]
            },
            pageflip: {
                src: [
                    'assets/js/*.js'
                ]
            },
            test: {
                src: [
                    'tests/assets/js/*.js'
                ]
            },
            options: {
                jshintrc: '.jshintrc',
                reporter: isIntegration ? 'checkstyle' : null,   // without this patch I need to use undefined
                reporterOutput: isIntegration ? 'logs/jshint_cs.xml' : null
            }
        }
    });
```