### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
     "url": "http://gruntjs.com/"
   },
   "repository": "gruntjs/grunt-contrib-jshint",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/gruntjs/grunt-contrib-jshint/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/