### PR TITLE
Make relative reporterOutput paths optional

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -20,7 +20,8 @@ module.exports = function(grunt) {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       force: false,
-      reporter: null
+      reporter: null,
+      reporterOutputRelative: true
     });
 
     // Report JSHint errors but dont fail the task

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -156,7 +156,7 @@ exports.init = function(grunt) {
     var reporterOutputDir;
     // Get reporter output directory for relative paths in reporters
     if (options.hasOwnProperty('reporterOutput')) {
-      if(options.reporterOutputRelative) {
+      if (options.reporterOutputRelative) {
         reporterOutputDir = path.dirname(options.reporterOutput);
       }
       delete options.reporterOutput;
@@ -196,7 +196,7 @@ exports.init = function(grunt) {
     var allData = [];
     cliOptions.args = files;
     cliOptions.reporter = function(results, data) {
-      if(reporterOutputDir) {
+      if (reporterOutputDir) {
         results.forEach(function(datum) {
           datum.file = path.relative(reporterOutputDir, datum.file);
         });

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -156,7 +156,9 @@ exports.init = function(grunt) {
     var reporterOutputDir;
     // Get reporter output directory for relative paths in reporters
     if (options.hasOwnProperty('reporterOutput')) {
-      reporterOutputDir = path.dirname(options.reporterOutput);
+      if(options.reporterOutputRelative) {
+        reporterOutputDir = path.dirname(options.reporterOutput);
+      }
       delete options.reporterOutput;
     }
 
@@ -164,7 +166,7 @@ exports.init = function(grunt) {
     var reporter = exports.selectReporter(options);
 
     // Remove bad options that may have came in from the cli
-    ['reporter', 'jslint-reporter', 'checkstyle-reporter', 'show-non-errors'].forEach(function(opt) {
+    ['reporter', 'reporterOutputRelative', 'jslint-reporter', 'checkstyle-reporter', 'show-non-errors'].forEach(function(opt) {
       if (options.hasOwnProperty(opt)) {
         delete options[opt];
       }
@@ -194,9 +196,11 @@ exports.init = function(grunt) {
     var allData = [];
     cliOptions.args = files;
     cliOptions.reporter = function(results, data) {
-      results.forEach(function(datum) {
-        datum.file = reporterOutputDir ? path.relative(reporterOutputDir, datum.file) : datum.file;
-      });
+      if(reporterOutputDir) {
+        results.forEach(function(datum) {
+          datum.file = path.relative(reporterOutputDir, datum.file);
+        });
+      }
       reporter(results, data, options);
       allResults = allResults.concat(results);
       allData = allData.concat(data);


### PR DESCRIPTION
As discussed in #202, making the reporter output filenames causes problems in some cases - in my specific usecase, I'm using the junit reporter, and putting the reporter output into a folder for use in CircleCI reporting. 
This change adds the `reportOutputRelative` option that can be set to false to disable the altering of paths to be relative.