### PR TITLE
Bump package version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-next:
+v0.11.2:
+  date: 2015-08-13
   changes:
     - Update to JSHint ~2.8.0.
 v0.11.2:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-jshint",
   "description": "Validate files with JSHint",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"


### PR DESCRIPTION
Since jshint was updated to 2.8.0 we should release the updated for version for grunt.