### PR TITLE
Remove ^ from jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "hooker": "^0.2.3",
-    "jshint": "^2.8.0"
+    "jshint": "2.8.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
jshint 2.9.0 is causing problems instead we should update grunt-contrib-jshint and jshint version at same time to stop problems happening and so the user can choose the correct version they want to use.