### PR TITLE
Bump version to 0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-jshint",
   "description": "Validate files with JSHint",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "hooker": "^0.2.3",
-    "jshint": "^2.8.0"
+    "jshint": "2.9.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Bump is so we can use 2.9.0 instead of requiring the latest stable version in every release.