### PR TITLE
Update jshint to fix regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "hooker": "^0.2.3",
-    "jshint": "~2.9.1"
+    "jshint": "^2.9.2"
   },
   "devDependencies": {
     "grunt": "^1.0.0",


### PR DESCRIPTION
There were a few regressions with the 2.9.1 jshint release that are fixed with the latest release