### PR TITLE
Created an option to not make the paths relative to the reporter output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Default: `null`
 
 Specify a filepath to output the results of a reporter. If `reporterOutput` is specified then all output will be written to the given filepath instead of printed to stdout.
 
+#### makeFilesRelative
+
+Type: `Boolean`  
+Default: `true`
+
+Set `makeFilesRelative` to `false` to make the file paths absolue. instead of being relative to the output directory. 
+
+
 ### Usage examples
 
 #### Wildcards

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -197,7 +197,7 @@ exports.init = function(grunt) {
     var allData = [];
     cliOptions.args = files;
     cliOptions.reporter = function(results, data) {
-      if (reporterOutputDir) {
+      if (reporterOutputDir && options.makeFilesRelative !== false) {
         results.forEach(function(datum) {
           datum.file = path.relative(reporterOutputDir, datum.file);
         });


### PR DESCRIPTION
I was having issues with jshint-junit-reporter which couldn't assign the errors to the files anymore because the files became relative to the report output directory. I fixed it by adding an option to make the file paths absolute, instead of being relative to the output directory. 
