### PR TITLE
Add verbose to options

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "devDependencies": {
     "grunt": "^1.0.0",
     "grunt-contrib-internal": "^1.2.3",
-    "grunt-contrib-nodeunit": "^1.0.0"
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "jshint-stylish": "^2.2.1"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -130,7 +130,7 @@ exports.init = function(grunt) {
   // Run JSHint on the given files with the given options
   exports.lint = function(files, options, done) {
     var cliOptions = {
-      verbose: grunt.option('verbose'),
+      verbose: grunt.option('verbose') || !!options.verbose,
       extensions: ''
     };
 
@@ -189,7 +189,10 @@ exports.init = function(grunt) {
         }
       }
       // pass all of the remaining options directly to jshint
-      cliOptions.config = options;
+      cliOptions.config = Object.assign({},options);
+      //options is passed to the reporter hence we need to leave verbose on  options
+      //but verbose is an in valid option for jshint, therefore remove it from config.
+      delete cliOptions.config.verbose;
     }
 
     // Run JSHint on all file and collect results/data

--- a/tasks/lib/jshint.js
+++ b/tasks/lib/jshint.js
@@ -189,7 +189,8 @@ exports.init = function(grunt) {
         }
       }
       // pass all of the remaining options directly to jshint
-      cliOptions.config = Object.assign({},options);
+      var extend = require('util')._extend;
+      cliOptions.config = extend({},options);
       //options is passed to the reporter hence we need to leave verbose on  options
       //but verbose is an in valid option for jshint, therefore remove it from config.
       delete cliOptions.config.verbose;

--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -101,6 +101,38 @@ exports.jshint = {
       test.done();
     });
   },
+  alternateReporterVerboseTrue: function(test) {
+    test.expect(2);
+    var files = [path.join(fixtures, 'nodemodule.js')];
+    var options = {
+      reporter: require('jshint-stylish'), 
+      verbose: true
+    };
+    stdoutEqual(function() {
+      jshint.lint(files, options, function() {});
+    }, function(result) {
+      var reg = /line.*\((W\d*)\)/g;
+      test.ok(jshint.usingGruntReporter === false, 'Should NOT be using the default grunt reporter.');
+      test.ok(reg.test(result) === true, 'Should have reported errors with with verbose option');
+      test.done();
+    });
+  },
+    alternateReporterVerboseFalse: function(test) {
+    test.expect(2);
+    var files = [path.join(fixtures, 'nodemodule.js')];
+    var options = {
+      reporter: require('jshint-stylish'), 
+      verbose: false
+    };
+    stdoutEqual(function() {
+      jshint.lint(files, options, function() {});
+    }, function(result) {
+      var reg = /line.*\((W\d*)\)/g;
+      test.ok(jshint.usingGruntReporter === false, 'Should NOT be using the default grunt reporter.');
+      test.ok(reg.test(result) === false, 'Should have reported errors with without verbose option');
+      test.done();
+    });
+  },
   reporterOutput: function(test) {
     test.expect(1);
     var result = grunt.file.read(path.join('tmp', 'report.xml'));


### PR DESCRIPTION
The user can now have a verbose key in the options object of the jshint setting in their grunt file. This setting will be passed to the reporter. Unit test cases are also included.  Example config below.
Fixes issue #208 and #210 
```
jshint: {
            all: ["**/*.js", "**/*.json"],
            options: {
                globals: {
                    logger: true
                  ##},
                esversion: 6,
                sub: true,
                expr: true,
                ignores: ['./node_modules/**/*.js', './node_modules/**/*.json'],
                reporter: require('jshint-stylish'),
                verbose: true

            }
        }
```