### PR TITLE
Ensures errors in stdoutEqual callback are logged

### DIFF
--- a/test/jshint_test.js
+++ b/test/jshint_test.js
@@ -21,7 +21,12 @@ var stdoutEqual = function(callback, done) {
     }
   });
   // Execute the logging code to be tested.
-  callback();
+  try {
+    callback();
+  } catch (error) {
+    hooker.unhook(process.stdout, 'write');
+    throw error;
+  }
   // Restore process.stdout.write to its original value.
   hooker.unhook(process.stdout, 'write');
   // Actually test the actually-logged stdout string to the expected value.


### PR DESCRIPTION
Since stdout is redirected while the callback is executed, any errors the callback throws are suppressed and never logged. This unhooks `process.stdout.write` after catching an error in `callback()` and re-throws it so it will be logged.