### PR TITLE
Upgrading Jshint to 2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "hooker": "^0.2.3",
-    "jshint": "~2.12.0"
+    "jshint": "~2.13.0"
   },
   "devDependencies": {
     "grunt": "^1.3.0",


### PR DESCRIPTION
2.13 includes support for optional chaining and other important updates.